### PR TITLE
Fix Experience calculator 

### DIFF
--- a/src/models/education.py
+++ b/src/models/education.py
@@ -5,7 +5,7 @@ from .baseModel import BaseModel
 
 class Education(BaseModel):
     def __init__(self, institute:str, startDate:float|datetime, endDate:float|datetime, score:float, maxScore:float):
-        self.institue = institute
+        self.institute = institute
         self.startDate = self.parseDate(startDate)
         self.endDate = self.parseDate(endDate)
         self.score = score
@@ -23,7 +23,7 @@ class Education(BaseModel):
 
     def getDict(self) -> dict[str, Any]:
         return {
-            "institute": self.institue,
+            "institute": self.institute,
             "startDate": self.stringifyDate(self.startDate),
             "endDate": self.stringifyDate(self.endDate),
             "score": self.score,

--- a/src/models/skill.py
+++ b/src/models/skill.py
@@ -31,7 +31,7 @@ class Skill(BaseModel):
                 1 - Intermediate
                 2 - Master        
         """
-        startDate = datetime.today() - relativedelta(year=round(experience))
+        startDate = datetime.today() - relativedelta(years=round(experience))
         return cls(title, startDate, proficiency)
 
     @classmethod
@@ -45,9 +45,10 @@ class Skill(BaseModel):
     @property
     def experience(self):
         try:
-            return (datetime.today() - self.startDate).days / 365.25
-        except TypeError:
-            return ""
+            exp = (datetime.today() - self.startDate).days / 365.25
+            return max(0, exp)
+        except (TypeError, AttributeError):
+            return 0
 
     def getDict(self) -> dict[str, Any]:
         return {

--- a/tests/modelTest.py
+++ b/tests/modelTest.py
@@ -42,10 +42,10 @@ class TestModels(unittest.TestCase):
             "maxScore": 10.0
         }
         e = Education(**data)
-        self.assertEqual(e.institue, data["institute"])
+        self.assertEqual(e.institute, data["institute"])
         self.assertAlmostEqual(e.score, data["score"])
         e2 = Education.fromDict(data)
-        self.assertEqual(e2.institue, data["institute"])
+        self.assertEqual(e2.institute, data["institute"])
 
     def test_skill_init_and_fromDict(self):
         now = datetime.now().timestamp()
@@ -102,7 +102,7 @@ class TestModels(unittest.TestCase):
         skills = [Skill("Python", datetime.now(), 2)]
         ci = CandidateInfo(contact, education, experience, projects, skills)
         self.assertEqual(ci.contact.name, "John Doe")
-        self.assertEqual(ci.education[0].institue, "Test University")
+        self.assertEqual(ci.education[0].institute, "Test University")
         self.assertEqual(ci.experience[0].title, "Developer")
         self.assertEqual(ci.projects[0].title, "ResumeGen")
         self.assertEqual(ci.skills[0].title, "Python")
@@ -177,7 +177,7 @@ class TestModels(unittest.TestCase):
             "maxScore": None
         }
         e = Education.fromDict(incomplete_data)
-        self.assertEqual(e.institue, "")
+        self.assertEqual(e.institute, "")
         self.assertEqual(e.startDate, None)
         self.assertEqual(e.endDate, None)
         self.assertEqual(e.score, None)


### PR DESCRIPTION
## 🔧 Fix: Bugs in `Skill` Model and Typo Corrections 
fixes #2 

This PR resolves critical issues in the `Skill` model related to experience calculation and corrects typo throughout the codebase for consistency 

---

### ✅ Changes Made

#### 1. Fixed `relativedelta` Bug in `Skill.fromExperience()`
- **File**: `src/models/skill.py`  
- **Line**: 28  
- **Change**:  
  `relativedelta(year=round(experience))` → `relativedelta(years=round(experience))`  
- **Issue Explanation**:

The code used `relativedelta(year=...)` which **sets the year directly** instead of subtracting years.

- For example, if `experience = 2`,  
  `relativedelta(year=2)` sets the date’s year to the year 2 AD — which is wrong.

- What we want instead is to subtract years relative to today:  
  `relativedelta(years=2)` means "2 years ago from today."

So the bug caused the skill start date to be a fixed (and incorrect) year instead of a date relative to how many years of experience the skill represents. Docstring says experience is a calendar year (e.g., 2020.5).

## The Updated Docstring

```python
experience (float): Number of years of experience (e.g., 2.5 means 2.5 years ago)
``` 

#### 2. Improved `experience` Property Error Handling
- **File**: `src/models/skill.py`  
- **Lines**: 54–57  
- **Fixes**:
  - Return `max(0, exp)` to prevent negative experience values.
  - Return `0` instead of empty string `""` for type consistency.
  - Catch `AttributeError` along with `TypeError`.

#### 3. Fixed Typo in `Education` Model and in the whole codebae 
- **File**: `src/models/education.py`  
- **Change**:  
  `self.institue = institute` → `self.institute = institute`
  and in ModelTest.py
